### PR TITLE
Make update antrean `jenisresep` params optional

### DIFF
--- a/.changeset/lucky-books-add.md
+++ b/.changeset/lucky-books-add.md
@@ -1,0 +1,5 @@
+---
+'@ssecd/jkn': patch
+---
+
+make `jenisresep` in update waktu antrean optional

--- a/src/antrean.ts
+++ b/src/antrean.ts
@@ -299,7 +299,7 @@ export class Antrean extends BaseApi<'antrean'> {
 		waktu: number;
 
 		/** khusus yang sudah implementasi antrean farmasi */
-		jenisresep: 'Tidak ada' | 'Racikan' | 'Non racikan';
+		jenisresep?: 'Tidak ada' | 'Racikan' | 'Non racikan';
 	}) {
 		return this.send({
 			path: `/antrean/updatewaktu`,


### PR DESCRIPTION
Parameter `jenisresep` pada `Antrean#updateWaktuAntrean` bersifat optional untuk yang sudah implementasi antrean farmasi. PR ini memperbaiki kesalahan type tersebut.